### PR TITLE
LIBSEARCH-65. Coerce JSON "title" into string

### DIFF
--- a/app/searchers/quick_search/world_cat_knowledge_base_searcher.rb
+++ b/app/searchers/quick_search/world_cat_knowledge_base_searcher.rb
@@ -16,7 +16,9 @@ module QuickSearch
 
         @response['entries'].each do |value|
           result = OpenStruct.new
-          result.title = value['title']
+          # Coercing title to string, because sometimes it isn't.
+          # See LIBSEARCH-65
+          result.title = value['title'].to_s
           result.link = value['links'][2]['href']
           result.author = value['kb:publisher']
           result.date = published(value)


### PR DESCRIPTION
The "title" value for an entry returned by WorldCat may not always
be a string. This was discovered accidentally when searching for
the term "music scores", and the first result has a title of "[1]",
which was return without the quotes in the JSON result from WorldCat.

When run through a JSON parser, the "[1]" was interpreted as an array
with a single element, and caused problems when treated like a string.

This fix simply coerces the "title" field into a string using the
"to_s" method, to ensure that the value will always be a string.

https://issues.umd.edu/browse/LIBSEARCH-65