### PR TITLE
LIBSEARCH-66. Modified code to URL encode search term

### DIFF
--- a/app/searchers/quick_search/world_cat_knowledge_base_searcher.rb
+++ b/app/searchers/quick_search/world_cat_knowledge_base_searcher.rb
@@ -35,7 +35,7 @@ module QuickSearch
 
     def parameters
       {
-        'q' => http_request_queries['not_escaped'],
+        'q' => http_request_queries['uri_escaped'],
         'itemsPerPage' => '3',
         'institution_id' => QuickSearch::Engine::WORLD_CAT_KNOWLEDGE_BASE_CONFIG['institution_id'],
         'wskey' => QuickSearch::Engine::WORLD_CAT_KNOWLEDGE_BASE_CONFIG['wskey']


### PR DESCRIPTION
Modified the code to use URL encoded (also know as "percent-encoding")
search terms for the HTTP request.

This ensures that search terms that include whitespace or quotes are
properly encoded for the request.

https://issues.umd.edu/browse/LIBSEARCH-66